### PR TITLE
Fix type mismatch for block annotation

### DIFF
--- a/Framework/View/Element/BlockInterfacePlugin.php
+++ b/Framework/View/Element/BlockInterfacePlugin.php
@@ -39,7 +39,7 @@ class BlockInterfacePlugin
 
         return $this->annotator->annotateBlock(
             $name,
-            $result,
+            $result ?? '',
             $subject
         );
     }


### PR DESCRIPTION
In this case `$proceed()` can return `null` but `annotateBlock` is expecting a string